### PR TITLE
System description

### DIFF
--- a/.actionspanel/buttons.yml
+++ b/.actionspanel/buttons.yml
@@ -1,0 +1,4 @@
+buttons:
+  - title: Refresh Project Table
+    action: "make_project_table"
+    description: Refresh Project Table

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -25,6 +25,8 @@ jobs:
         run: git checkout system-description
       - name: Update project table
         run: python make_project_table.py ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout project-table
+        run: git checkout project-table
       - name: Commit
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -22,11 +22,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install pygithub
       - name: Checkout correct branch
-        run: git checkout project-table
+        run: git checkout system-description
       - name: Update project table
         run: python make_project_table.py
       - name: Commit and push
         run: |
           git add .
           git commit -m "actions-bot: Update project table"
+          echo ${{ secrets.GITHUB_TOKEN }}
           git push -u origin project-table ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -25,8 +25,12 @@ jobs:
         run: git checkout system-description
       - name: Update project table
         run: python make_project_table.py ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit and push
+      - name: Commit
         run: |
-          git add .
-          git commit -m "actions-bot: Update project table"
-          git push -u origin project-table
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "git-bot: Update table" -a
+      - name: Push changes
+          uses: ad-m/github-push-action@master
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -1,0 +1,30 @@
+name: update_project_table
+on:
+  issues:
+    types: [opened, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned]
+  pull_request:
+    types: [assigned, unassigned, labeled, unlabeled, opened, closed, reopened, ready_for_review, review_requested]
+
+jobs:
+  update_table:
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pygithub
+      - name: Checkout correct branch
+        run: git checkout project-table
+      - name: Update project table
+        run: python make_project_table.py
+      - name: Commit and push
+        run: |
+          git add .
+          git commit -m "actions-bot: Update project table"
+          git push -u origin project-table ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update_table:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
         with:
@@ -15,6 +16,15 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.x'
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip # This path is specific to Ubuntu
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -34,3 +34,4 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: project-table

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -1,13 +1,15 @@
 name: update_project_table
 on:
-  push:
-  issues:
-    types: [opened, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned]
-  pull_request:
-    types: [assigned, unassigned, labeled, unlabeled, opened, closed, reopened, ready_for_review, review_requested]
+  # push:
+  # issues:
+  #   types: [opened, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned]
+  # pull_request:
+  #  types: [assigned, unassigned, labeled, unlabeled, opened, closed, reopened, ready_for_review, review_requested]
+  repository_dispatch:
 
 jobs:
   update_table:
+    if: github.event.action == 'make_project_table'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -16,15 +16,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.x'
-      - name: Cache pip
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip # This path is specific to Ubuntu
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -24,10 +24,9 @@ jobs:
       - name: Checkout correct branch
         run: git checkout system-description
       - name: Update project table
-        run: python make_project_table.py
+        run: python make_project_table.py ${{ secrets.GITHUB_TOKEN }}
       - name: Commit and push
         run: |
           git add .
           git commit -m "actions-bot: Update project table"
-          echo ${{ secrets.GITHUB_TOKEN }}
-          git push -u origin project-table ${{ secrets.GITHUB_TOKEN }}
+          git push -u origin project-table

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -31,6 +31,6 @@ jobs:
           git config --local user.name "GitHub Action"
           git commit -m "git-bot: Update table" -a
       - name: Push changes
-          uses: ad-m/github-push-action@master
-          with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -24,9 +24,14 @@ jobs:
       - name: Checkout correct branch
         run: git checkout system-description
       - name: Update project table
-        run: python make_project_table.py ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir tmp
+          cd tmp
+          python ../make_project_table.py ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout project-table
-        run: git checkout project-table
+        run: |
+          git checkout project-table
+          mv project_table.md ../
       - name: Commit
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/update_table.yml
+++ b/.github/workflows/update_table.yml
@@ -1,5 +1,6 @@
 name: update_project_table
 on:
+  push:
   issues:
     types: [opened, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, demilestoned]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -72,9 +72,88 @@ and means for example that the execution time/date can be written directly
 into a markdown cell. 
 
 ## Project Plan
+A semi-up-to-date version of the project plan is found at 
+[project_table.md](https://github.com/HERA-Team/hera-validation/blob/project-table/project_table.md).
+
 To create a simple tabulated version of the Project Plan, download the repo, save a
 [personal access token](https://github.com/settings/tokens) to a file called `.pesonal-github-token`,
 (ensure there is no trailing "\n" in the file)
 and run `make_project_table.py` at the root directory. 
 Note that you will need python 3.4+ and the `pygithub` code to run this script (`pip install pygithub`).
-A semi-up-to-date version of this table is found at [project_table.md](./project_table.md).
+
+Do this on the `project-table` branch to update our "current" table linked above.
+
+## Project Organization
+To track where the validation effort is currently at, we rely on a particular structure
+in this repository. We first ask you to review the overall structure of the test series
+(above)[#structure-of-this-repository] as well as in the 
+[project table](https://github.com/HERA-Team/hera-validation/blob/project-table/project_table.md).
+This will indicate what the relevant step number is for any proposed test. 
+
+### Proposing a new test
+To propose a new test, create a 
+(new test-proposal issue)[https://github.com/HERA-Team/hera-validation/issues/new?assignees=&labels=formal-test&template=test_proposal.md&title=Step+X.X%3A+%3CShort+Title%3E].
+Fill out the information in the issue template with as much detail as possible, in 
+particular, which simulation components will be required (and their parameters), and
+which pipeline components will be required. If you have access, you can also update the
+tags applied to the issue. In particular, there are specific tags for the following:
+* Simulator used
+* Simulated components (eg. GLEAM, GSM, gains, RFI, ...)
+* Pipeline components required (eg. pspec, abscal, ...)
+It is these tags (not the description in the actual issue body) that are displayed in our
+project table summary, so this is important. However, we will add these tags during our
+weekly review if you are unable to do it.
+
+Finally, you should (if you can) apply the `status:proposed` tag, to inform the team that
+this is a new test to be considered for formal inclusion in the test series. Once reviewed
+at our weekly meeting, we will either promote this to `status:accepted` or demote it
+to `status:rejected`. 
+
+If you are willing to do the work to perform the test you have proposed, you may also
+assign yourself. You may also contact any others you think might be able to help you
+and assign them. 
+
+### Weekly Review
+As has already been mentioned, during the weekly validation meeting, we will assess any
+new issues with the tag `status:proposed`, and update the status tag, assignees and 
+metadata tags (simulators, components, pipelines, etc.). It will be particularly 
+helpful if the proposer of the test could be present at the weekly meeting directly 
+following the proposal.  
+
+In addition to updating these tags, the team will decide on two things:
+1. Which (project)[projects] to formally add the proposed test to (these correspond to 
+   the various validation steps)
+2. Which (milestone)[milestones] to add the proposed test to (if any). These represent 
+   broader goals of the project. For example, the first milestone is 
+   (H1C_IDR2)[https://github.com/HERA-Team/hera-validation/milestone/4]. This sets
+   basic priorities for the team.
+   
+### Starting/Running a Test
+To start working on a test, first create a branch (preferrably named after the test
+step explicitly), and proceed to edit a (validation template)[notebook-template.ipynb].
+After your first commit/push, create a _draft_ PR, which in the body explicitly 
+references the original issue proposing the test. From this time, the original
+test proposal will be considered frozen, and all development of the ideas, and discussion,
+will be had in the PR itself. It is important that the original issue be linked explicitly
+with a line such as "Fixes #37", in order for the issue tracking to work as we want. 
+
+In detail, doing so will automatically set the status tag on the original issue to
+`status:active`, and also automatically move it from "To Do" to "In Progress" in the 
+relevant project. 
+
+Do *not* set the Project/Milestone for the PR (but do assign anyone who is part of the
+execution of the PR). Doing so duplicates the step in the Project tracker.
+
+While your PR is in draft form, we will attempt to discuss updates on it weekly at our
+meeting (if time permits). When it is ready for final review, set it to a non-draft PR,
+and we will review it _as a team_ at the next available meeting. We will also assign
+a single final reviewer who will give the thumbs up for merging.
+
+### Tracking Progress
+If you wish to track the progress of the validation effort, the most in-depth information
+can be determined from the (projects)[projects] page. Each Project is a major validation
+"Step", and opening any particular project will show which sub-steps are to do, in progress
+or completed. 
+
+Do remember that projects are irrespective of overall goal/milestone, and so you should
+filter them by the current milestone as well.  

--- a/make_project_table.py
+++ b/make_project_table.py
@@ -13,13 +13,16 @@ table_header = """Status     | #    | Simulator(s) | Sim. Components | Analysis 
 """
 
 if __name__=="__main__":
-    if not os.path.exists('.personal-github-token'):
-        raise ValueError("You do not yet have a personal access token for github installed. Create one at https://github.com/settings/tokens "
-              "and paste it into the file .personal-github-token (notice leading .) in this directory.")
-
     if len(sys.argv) > 1:
         GH_TOKEN = sys.argv[-1]
     else:
+        if not os.path.exists('.personal-github-token'):
+            raise ValueError(
+                "You do not yet have a personal access token for github installed. Create one at "
+                "https://github.com/settings/tokens "
+                "and paste it into the file .personal-github-token (notice leading .) in this "
+                "directory.")
+
         with open(".personal-github-token") as fl:
             GH_TOKEN = fl.read()
 

--- a/make_project_table.py
+++ b/make_project_table.py
@@ -30,16 +30,6 @@ if __name__=="__main__":
     repo = g.get_repo("HERA-Team/hera-validation")
 
     projects = repo.get_projects()
-
-    # issues = repo.get_issues(state='all')
-    # prs = repo.get_pulls(state='all')
-    #
-    # # Isolate issues/prs that define formal tests/steps
-    # steps = [issue for issue in everything if "formal-test" in [lbl.name for lbl in issue.labels]]
-    #
-    # everything = [issue for issue in issues] + [pr for pr in prs]
-    # This finds anything with the pattern X.X.X in a string (i.e. the STEP.MAJOR part of a
-    # step identifier)
     step_number_pattern = re.compile(r"(-?\d+(\.\d+){0,2})")
 
     tables = """## Project Plan

--- a/make_project_table.py
+++ b/make_project_table.py
@@ -13,6 +13,8 @@ table_header = """Status     | #    | Simulator(s) | Sim. Components | Analysis 
 """
 
 if __name__=="__main__":
+    print(sys.argv)
+
     if len(sys.argv) > 1:
         GH_TOKEN = sys.argv[-1]
     else:

--- a/make_project_table.py
+++ b/make_project_table.py
@@ -6,6 +6,7 @@ Requires python 3.4+ and pygithub to be installed.
 from github import Github
 import re
 import os
+import sys
 
 table_header = """Status     | #    | Simulator(s) | Sim. Components | Analysis Components | Assigned |
 -----------| -----|--------------|-----------------|---------------------|----------|
@@ -16,8 +17,11 @@ if __name__=="__main__":
         raise ValueError("You do not yet have a personal access token for github installed. Create one at https://github.com/settings/tokens "
               "and paste it into the file .personal-github-token (notice leading .) in this directory.")
 
-    with open(".personal-github-token") as fl:
-        GH_TOKEN = fl.read()
+    if len(sys.argv) > 1:
+        GH_TOKEN = sys.argv[-1]
+    else:
+        with open(".personal-github-token") as fl:
+            GH_TOKEN = fl.read()
 
     g = Github(GH_TOKEN)
     repo = g.get_repo("HERA-Team/hera-validation")

--- a/make_project_table.py
+++ b/make_project_table.py
@@ -35,6 +35,8 @@ if __name__=="__main__":
     step_number_pattern = re.compile(r"(-?\d+(\.\d+){0,2})")
 
     tables = """## Project Plan
+[![Run Action](https://github-action-button.web.app/buttons/simple.svg?name=Refresh%20Project%20Table&eventType=make_project_table&type=simple)](https://github-action-button.web.app/repos/HERA-Team/hera-validation/button?name=Refresh%20Project%20Table&eventType=make_project_table&type=simple)
+
 Here follows a formal plan for envisaged tests, automatically generated from our Projects. 
 This list is *not final*: it may be extended or 
 modified at any time. However, it provides a reasonable snapshot of the current status and plans of 

--- a/project_table.md
+++ b/project_table.md
@@ -1,4 +1,6 @@
 ## Project Plan
+[![Run Action](https://github-action-button.web.app/buttons/simple.svg?name=Refresh%20Project%20Table&eventType=make_project_table&type=simple)](https://github-action-button.web.app/repos/HERA-Team/hera-validation/button?name=Refresh%20Project%20Table&eventType=make_project_table&type=simple)
+
 Here follows a formal plan for envisaged tests, automatically generated from our Projects. 
 This list is *not final*: it may be extended or 
 modified at any time. However, it provides a reasonable snapshot of the current status and plans of 


### PR DESCRIPTION
This attempts to add a Github Action that re-creates the project table for every issue and PR edit/create/delete.

It creates the new project table in the `project-table` branch, and commits to that branch (so pointing to that branch's version of `project_table.md` will always be up to date). I'm not sure if that's going to be too slow, or have too many commits. Not sure if that's a problem. 

One way around it would be to, instead of re-building on every push/PR/issue, have a button on the readme which anyone can push to rebuild the table. It would even be nicer if, once the action is run, pushing the button _also_ took you to the document to view. But I'm not sure that's possible. Ooooh, actually the best way would be to have the button on the project table itself....
